### PR TITLE
Fix broken link to lambda role guide

### DIFF
--- a/instructions/2-lambda-function.md
+++ b/instructions/2-lambda-function.md
@@ -23,7 +23,7 @@ In the [first step of this guide](./1-voice-user-interface.md), we built the Voi
 
 5.  **There are two boxes labeled "Author from scratch" and "Blueprints". Click the radio button in the box titled "Author from scratch".** Then type a name for you lambda function, choose "Java 8" as the runtime.
 
-6.  **Set up your Lambda function role.**  If you haven't done this before, we have a [detailed walkthrough for setting up your first role for Lambda](https://github.com/alexa/alexa-cookbook/tree/master/aws/lambda-role.md).  If you have done this before, set your **Existing role** value to "lambda_basic_execution."
+6.  **Set up your Lambda function role.**  If you haven't done this before, we have a [detailed walkthrough for setting up your first role for Lambda](https://github.com/alexa/alexa-cookbook/blob/master/guides/aws-security-and-setup/lambda-role.md).  If you have done this before, set your **Existing role** value to "lambda_basic_execution."
 
     <img src="https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/2-9-lambda-function-role._TTH_.png" />
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The link to the lambda role was broken. I think I fixed it?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
